### PR TITLE
Fix lcore_id type

### DIFF
--- a/src/defaults.c
+++ b/src/defaults.c
@@ -158,7 +158,7 @@ void set_task_defaults(struct prox_cfg* prox_cfg, struct lcore_cfg* lcore_cfg_in
 		prox_cfg->cpe_table_ports[i] = -1;
 	}
 
-	for (uint8_t lcore_id = 0; lcore_id < RTE_MAX_LCORE; ++lcore_id) {
+	for (unsigned int lcore_id = 0; lcore_id < RTE_MAX_LCORE; ++lcore_id) {
 		struct lcore_cfg *cur_lcore_cfg_init = &lcore_cfg_init[lcore_id];
 		cur_lcore_cfg_init->id = lcore_id;
 		for (uint8_t task_id = 0; task_id < MAX_TASKS_PER_CORE; ++task_id) {

--- a/src/prox_args.c
+++ b/src/prox_args.c
@@ -409,7 +409,7 @@ static int get_defaults_cfg(__attribute__((unused)) unsigned sindex, char *str, 
 			return -1;
 		}
 
-		for (uint8_t lcore_id = 0; lcore_id < RTE_MAX_LCORE; ++lcore_id) {
+		for (unsigned int lcore_id = 0; lcore_id < RTE_MAX_LCORE; ++lcore_id) {
 			struct lcore_cfg *cur_lcore_cfg_init = &lcore_cfg_init[lcore_id];
 			cur_lcore_cfg_init->id = lcore_id;
 			for (uint8_t task_id = 0; task_id < MAX_TASKS_PER_CORE; ++task_id) {
@@ -422,7 +422,7 @@ static int get_defaults_cfg(__attribute__((unused)) unsigned sindex, char *str, 
 	}
 
 	if (STR_EQ(str, "qinq tag")) {
-		for (uint8_t lcore_id = 0; lcore_id < RTE_MAX_LCORE; ++lcore_id) {
+		for (unsigned int lcore_id = 0; lcore_id < RTE_MAX_LCORE; ++lcore_id) {
 			struct lcore_cfg *cur_lcore_cfg_init = &lcore_cfg_init[lcore_id];
 			cur_lcore_cfg_init->id = lcore_id;
 			for (uint8_t task_id = 0; task_id < MAX_TASKS_PER_CORE; ++task_id) {
@@ -438,7 +438,7 @@ static int get_defaults_cfg(__attribute__((unused)) unsigned sindex, char *str, 
 			return -1;
 		}
 
-		for (uint8_t lcore_id = 0; lcore_id < RTE_MAX_LCORE; ++lcore_id) {
+		for (unsigned int lcore_id = 0; lcore_id < RTE_MAX_LCORE; ++lcore_id) {
 			struct lcore_cfg *cur_lcore_cfg_init = &lcore_cfg_init[lcore_id];
 			cur_lcore_cfg_init->id = lcore_id;
 			for (uint8_t task_id = 0; task_id < MAX_TASKS_PER_CORE; ++task_id) {
@@ -2192,7 +2192,7 @@ static void prox_set_core_mask(void)
 	struct lcore_cfg *lconf;
 
 	prox_core_clr();
-	for (uint8_t lcore_id = 0; lcore_id < RTE_MAX_LCORE; ++lcore_id) {
+	for (unsigned int lcore_id = 0; lcore_id < RTE_MAX_LCORE; ++lcore_id) {
 		lconf = &lcore_cfg_init[lcore_id];
 		if (lconf->n_tasks_all > 0 && lconf->targs[0].mode != MASTER) {
 			prox_core_set_active(lcore_id);


### PR DESCRIPTION
Now that we have more than 128 cores in a system, the type of this variable needs to be expanded