### PR TITLE
add irq score

### DIFF
--- a/rapid/format.yaml
+++ b/rapid/format.yaml
@@ -46,10 +46,8 @@ FlowSizeTest:
     Extent: extent
     Duplicated: duplicate
 IrqTest:
-  Environment: environment_file
-  Test: test
-  Buckets: buckets
-  Machine_data: machine_data
+  Score: AverageScore
+  MinScore: WorstScore
 ImpairTest:
   Environment: environment_file
   Test: test

--- a/rapid/rapid_flowsizetest.py
+++ b/rapid/rapid_flowsizetest.py
@@ -312,6 +312,8 @@ class FlowSizeTest(RapidTest):
                     tot_avg_rx_rate = end_data['pps_rx'] + (end_data['avg_bg_rate'] * len(self.background_machines))
                     endtotaltrafficrate = '|        | Total amount of traffic received by all generators during this test: {:>4.3f} Gb/s {:7.3f} Mpps {} |'.format(RapidTest.get_speed(tot_avg_rx_rate,size) , tot_avg_rx_rate, ' '*95)
                     RapidLog.info (endtotaltrafficrate)
+                else:
+                    tot_avg_rx_rate = end_data['pps_rx']
                 if endwarning:
                     RapidLog.info (endwarning)
                 if self.test['test'] != 'fixed_rate':

--- a/rapid/runrapid.py
+++ b/rapid/runrapid.py
@@ -144,9 +144,7 @@ class RapidTestManager(object):
                             sut_machine, background_machines)
                 elif test_param['test'] in ['irqtest']:
                     test = IrqTest(test_param,
-                            test_params['runtime'],
-                            test_params['TestName'],
-                            test_params['environment_file'],
+                            test_params,
                             self.machines)
                 elif test_param['test'] in ['warmuptest']:
                     test = WarmupTest(test_param,


### PR DESCRIPTION
A score is now calculated during the irq testing, so we have a single figure as an outcome. 100% means that all pollmode iterations were done very fast end were not interrupted by anything else (e.g. IRQs). That means the system is very well tuned. When the system returns scores below 80%, it is probably a good idea to inspect and find out why. The score is calculated by subtracting a penalty with a heavier weigth for longer interruptions